### PR TITLE
Add detailed earnings breakdown and pay period history

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -16,6 +16,8 @@ class Admin::DashboardController < Admin::BaseController
     @current_pay_period = @family.current_pay_period
     @payout_service = PayoutService.new(@family, current_adult)
     @payout_preview = @payout_service.payout_preview if @current_pay_period
+    @detailed_earnings = @current_pay_period.detailed_earnings_by_child if @current_pay_period
+    @period_ended = @current_pay_period&.end_date && @current_pay_period.end_date < Date.current
     
     # Notifications
     @unread_notifications = @family.payout_notifications

--- a/app/controllers/admin/pay_periods_controller.rb
+++ b/app/controllers/admin/pay_periods_controller.rb
@@ -1,0 +1,24 @@
+class Admin::PayPeriodsController < Admin::BaseController
+  def index
+    authorize :admin_dashboard, :index?
+    
+    @family = current_adult.family
+    @pay_periods = @family.pay_periods
+                          .includes(children: [:chore_completions, :extra_completions])
+                          .order(created_at: :desc)
+                          .limit(20)
+    
+    @detailed_earnings_by_period = {}
+    @pay_periods.each do |period|
+      @detailed_earnings_by_period[period.id] = period.detailed_earnings_by_child
+    end
+  end
+
+  def show
+    authorize :admin_dashboard, :index?
+    
+    @family = current_adult.family
+    @pay_period = @family.pay_periods.find(params[:id])
+    @detailed_earnings = @pay_period.detailed_earnings_by_child
+  end
+end

--- a/app/controllers/admin/payouts_controller.rb
+++ b/app/controllers/admin/payouts_controller.rb
@@ -11,6 +11,7 @@ class Admin::PayoutsController < Admin::BaseController
     end
 
     @earnings_by_child = @payout_preview[:earnings_by_child]
+    @detailed_earnings = @current_period.detailed_earnings_by_child
     @total_payout = @payout_preview[:total_payout]
     @can_payout = @payout_preview[:can_payout]
     @blocked_reason = @payout_preview[:blocked_reason]

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -197,7 +197,14 @@
     <!-- Pay Period Overview -->
     <% if @current_pay_period && @payout_preview && @payout_preview[:success] %>
       <div class="mb-8">
-        <h2 class="text-2xl font-bold text-gray-900 mb-6">Current Pay Period</h2>
+        <div class="flex items-center justify-between mb-6">
+          <h2 class="text-2xl font-bold text-gray-900">Current Pay Period</h2>
+          <% if @period_ended %>
+            <span class="bg-orange-100 text-orange-800 text-sm font-medium px-3 py-1 rounded-full">
+              Period Ended
+            </span>
+          <% end %>
+        </div>
         
         <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
           <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
@@ -238,18 +245,61 @@
             </div>
           </div>
           
-          <% if @payout_preview[:earnings_by_child].any? %>
+          <% if @detailed_earnings&.any? %>
             <div class="mt-6 pt-6 border-t border-gray-200">
-              <h4 class="font-semibold text-gray-900 mb-4">Earnings Breakdown</h4>
-              <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                <% @payout_preview[:earnings_by_child].each do |child_id, earnings| %>
+              <div class="flex items-center justify-between mb-4">
+                <h4 class="font-semibold text-gray-900">Earnings Breakdown</h4>
+                <%= link_to "View Full History", admin_pay_periods_path, 
+                          class: "text-blue-600 hover:text-blue-800 text-sm font-medium" %>
+              </div>
+              
+              <div class="space-y-4">
+                <% @detailed_earnings.each do |child_id, earnings| %>
                   <div class="bg-gray-50 rounded-lg p-4">
-                    <h5 class="font-medium text-gray-900"><%= earnings[:child].name %></h5>
-                    <p class="text-lg font-bold text-green-600">$<%= sprintf("%.2f", earnings[:total]) %></p>
-                    <p class="text-sm text-gray-600">
-                      Chores: $<%= sprintf("%.2f", earnings[:chore_earnings]) %> • 
-                      Extras: $<%= sprintf("%.2f", earnings[:extra_earnings]) %>
-                    </p>
+                    <div class="flex items-center justify-between mb-3">
+                      <h5 class="font-medium text-gray-900"><%= earnings[:child].name %></h5>
+                      <p class="text-lg font-bold text-green-600">$<%= sprintf("%.2f", earnings[:total]) %></p>
+                    </div>
+                    
+                    <div class="space-y-2 text-sm">
+                      <% if earnings[:completed_chores].any? %>
+                        <div>
+                          <p class="font-medium text-gray-700">Chores ($<%= sprintf("%.2f", earnings[:chore_earnings]) %>):</p>
+                          <ul class="ml-4 space-y-1">
+                            <% earnings[:completed_chores].each do |chore_data| %>
+                              <li class="text-gray-600">
+                                <%= chore_data[:chore].title %> 
+                                <span class="text-green-600">+$<%= sprintf("%.2f", chore_data[:amount]) %></span>
+                                <span class="text-gray-400">
+                                  (<%= chore_data[:completed_at]&.strftime("%m/%d") %>)
+                                </span>
+                              </li>
+                            <% end %>
+                          </ul>
+                        </div>
+                      <% end %>
+                      
+                      <% if earnings[:completed_extras].any? %>
+                        <div>
+                          <p class="font-medium text-gray-700">Extras ($<%= sprintf("%.2f", earnings[:extra_earnings]) %>):</p>
+                          <ul class="ml-4 space-y-1">
+                            <% earnings[:completed_extras].each do |extra_data| %>
+                              <li class="text-gray-600">
+                                <%= extra_data[:extra].title %>
+                                <span class="text-green-600">+$<%= sprintf("%.2f", extra_data[:amount]) %></span>
+                                <span class="text-gray-400">
+                                  (<%= extra_data[:completed_at]&.strftime("%m/%d") %>)
+                                </span>
+                              </li>
+                            <% end %>
+                          </ul>
+                        </div>
+                      <% end %>
+                      
+                      <% if earnings[:completed_chores].empty? && earnings[:completed_extras].empty? %>
+                        <p class="text-gray-500 italic">No earnings this period</p>
+                      <% end %>
+                    </div>
                   </div>
                 <% end %>
               </div>

--- a/app/views/admin/pay_periods/index.html.erb
+++ b/app/views/admin/pay_periods/index.html.erb
@@ -1,0 +1,135 @@
+<div class="min-h-screen bg-gray-50">
+  <!-- Header -->
+  <div class="bg-white shadow-sm border-b border-gray-200">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="flex justify-between items-center py-6">
+        <div>
+          <h1 class="text-3xl font-bold text-gray-900">
+            Pay Period History
+          </h1>
+          <p class="text-gray-600 mt-1">
+            Complete history of all pay periods and payouts
+          </p>
+        </div>
+        
+        <div class="flex items-center space-x-4">
+          <%= link_to admin_dashboard_path, 
+                      class: "text-gray-600 hover:text-gray-900 font-medium" do %>
+            ← Back to Dashboard
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Main Content -->
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <% if @pay_periods.any? %>
+      <div class="space-y-6">
+        <% @pay_periods.each do |period| %>
+          <% detailed_earnings = @detailed_earnings_by_period[period.id] %>
+          <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+            <div class="flex items-center justify-between mb-4">
+              <div>
+                <h3 class="text-xl font-bold text-gray-900">
+                  <%= period.start_date.strftime("%B %d") %> - <%= period.end_date.strftime("%B %d, %Y") %>
+                </h3>
+                <div class="flex items-center space-x-4 mt-1">
+                  <span class="text-sm text-gray-500">
+                    <%= period.frequency_description %>
+                  </span>
+                  <span class="text-sm <%= period.current_period? ? 'text-blue-600' : 'text-gray-500' %>">
+                    <%= period.current_period? ? 'Current Period' : 'Completed' %>
+                  </span>
+                  <% if period.last_payout_at %>
+                    <span class="text-sm text-green-600">
+                      Paid out <%= period.last_payout_at.strftime("%m/%d/%y") %>
+                    </span>
+                  <% end %>
+                </div>
+              </div>
+              
+              <div class="text-right">
+                <p class="text-2xl font-bold text-green-600">
+                  $<%= sprintf("%.2f", period.total_earnings_for_period) %>
+                </p>
+                <p class="text-sm text-gray-500">Total</p>
+              </div>
+            </div>
+            
+            <% if detailed_earnings&.any? %>
+              <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+                <% detailed_earnings.each do |child_id, earnings| %>
+                  <div class="bg-gray-50 rounded-lg p-4">
+                    <div class="flex items-center justify-between mb-3">
+                      <h4 class="font-medium text-gray-900"><%= earnings[:child].name %></h4>
+                      <p class="text-lg font-bold text-green-600">$<%= sprintf("%.2f", earnings[:total]) %></p>
+                    </div>
+                    
+                    <div class="space-y-2 text-sm">
+                      <% if earnings[:completed_chores].any? %>
+                        <div>
+                          <p class="font-medium text-gray-700">Chores ($<%= sprintf("%.2f", earnings[:chore_earnings]) %>):</p>
+                          <ul class="ml-4 space-y-1 max-h-32 overflow-y-auto">
+                            <% earnings[:completed_chores].each do |chore_data| %>
+                              <li class="text-gray-600">
+                                <%= chore_data[:chore].title %> 
+                                <span class="text-green-600">+$<%= sprintf("%.2f", chore_data[:amount]) %></span>
+                                <span class="text-gray-400">
+                                  (<%= chore_data[:completed_at]&.strftime("%m/%d") %>)
+                                </span>
+                              </li>
+                            <% end %>
+                          </ul>
+                        </div>
+                      <% end %>
+                      
+                      <% if earnings[:completed_extras].any? %>
+                        <div>
+                          <p class="font-medium text-gray-700">Extras ($<%= sprintf("%.2f", earnings[:extra_earnings]) %>):</p>
+                          <ul class="ml-4 space-y-1 max-h-32 overflow-y-auto">
+                            <% earnings[:completed_extras].each do |extra_data| %>
+                              <li class="text-gray-600">
+                                <%= extra_data[:extra].title %>
+                                <span class="text-green-600">+$<%= sprintf("%.2f", extra_data[:amount]) %></span>
+                                <span class="text-gray-400">
+                                  (<%= extra_data[:completed_at]&.strftime("%m/%d") %>)
+                                </span>
+                              </li>
+                            <% end %>
+                          </ul>
+                        </div>
+                      <% end %>
+                      
+                      <% if earnings[:completed_chores].empty? && earnings[:completed_extras].empty? %>
+                        <p class="text-gray-500 italic">No earnings this period</p>
+                      <% end %>
+                    </div>
+                  </div>
+                <% end %>
+              </div>
+            <% else %>
+              <p class="text-gray-500 text-center py-4">No earnings recorded for this period</p>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+      
+      <% if @pay_periods.count >= 20 %>
+        <div class="text-center mt-8">
+          <p class="text-gray-500">Showing most recent 20 pay periods</p>
+        </div>
+      <% end %>
+      
+    <% else %>
+      <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+        <div class="text-center py-8">
+          <h3 class="text-lg font-medium text-gray-900 mb-2">No Pay Periods Yet</h3>
+          <p class="text-gray-500">
+            Pay periods will appear here once children start completing chores and earning money.
+          </p>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/payouts/show.html.erb
+++ b/app/views/admin/payouts/show.html.erb
@@ -51,22 +51,63 @@
         
         <!-- Individual Child Earnings -->
         <div class="space-y-4">
-          <h3 class="font-semibold text-gray-900">Individual Earnings</h3>
+          <h3 class="font-semibold text-gray-900">Detailed Earnings Breakdown</h3>
           
-          <% @earnings_by_child.each do |child_id, earnings| %>
-            <div class="bg-gray-50 rounded-lg p-4 flex justify-between items-center">
-              <div>
+          <% @detailed_earnings.each do |child_id, earnings| %>
+            <div class="bg-gray-50 rounded-lg p-4">
+              <div class="flex justify-between items-center mb-4">
                 <h4 class="font-medium text-gray-900"><%= earnings[:child].name %></h4>
-                <div class="text-sm text-gray-600 mt-1">
-                  Chores: $<%= sprintf("%.2f", earnings[:chore_earnings]) %> • 
-                  Extras: $<%= sprintf("%.2f", earnings[:extra_earnings]) %>
-                </div>
-              </div>
-              
-              <div class="text-right">
                 <p class="text-xl font-bold text-green-600">
                   $<%= sprintf("%.2f", earnings[:total]) %>
                 </p>
+              </div>
+              
+              <div class="space-y-3 text-sm">
+                <% if earnings[:completed_chores].any? %>
+                  <div>
+                    <p class="font-medium text-gray-700 mb-2">Chores ($<%= sprintf("%.2f", earnings[:chore_earnings]) %>):</p>
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-2 ml-4">
+                      <% earnings[:completed_chores].each do |chore_data| %>
+                        <div class="bg-white rounded px-3 py-2 flex justify-between items-center">
+                          <span class="text-gray-700">
+                            <%= chore_data[:chore].title %>
+                            <span class="text-gray-400 text-xs block">
+                              Completed: <%= chore_data[:completed_at]&.strftime("%m/%d at %l:%M%P") %>
+                            </span>
+                          </span>
+                          <span class="text-green-600 font-medium">
+                            +$<%= sprintf("%.2f", chore_data[:amount]) %>
+                          </span>
+                        </div>
+                      <% end %>
+                    </div>
+                  </div>
+                <% end %>
+                
+                <% if earnings[:completed_extras].any? %>
+                  <div>
+                    <p class="font-medium text-gray-700 mb-2">Extras ($<%= sprintf("%.2f", earnings[:extra_earnings]) %>):</p>
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-2 ml-4">
+                      <% earnings[:completed_extras].each do |extra_data| %>
+                        <div class="bg-white rounded px-3 py-2 flex justify-between items-center">
+                          <span class="text-gray-700">
+                            <%= extra_data[:extra].title %>
+                            <span class="text-gray-400 text-xs block">
+                              Completed: <%= extra_data[:completed_at]&.strftime("%m/%d at %l:%M%P") %>
+                            </span>
+                          </span>
+                          <span class="text-green-600 font-medium">
+                            +$<%= sprintf("%.2f", extra_data[:amount]) %>
+                          </span>
+                        </div>
+                      <% end %>
+                    </div>
+                  </div>
+                <% end %>
+                
+                <% if earnings[:completed_chores].empty? && earnings[:completed_extras].empty? %>
+                  <p class="text-gray-500 italic text-center py-4">No earnings this period</p>
+                <% end %>
               </div>
             </div>
           <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
       end
     end
     resources :history, only: [:index]
+    resources :pay_periods, only: [:index, :show]
     resource :payout, only: [:show, :create]
     resource :settings, only: [:show, :update]
     resources :reviews, only: [:index] do


### PR DESCRIPTION
### Detailed Earnings Display
- Add detailed_earnings_by_child method to PayPeriod model with itemized chores/extras
- Update dashboard to show specific chore/extra titles, dates, and amounts
- Add "Period Ended" badge when pay period end date has passed
- Display completion timestamps for each earning item

### Pay Period History
- Create Admin::PayPeriodsController for historical pay period management
- Build comprehensive history view showing all past pay periods with full details
- Include period dates, status, payout dates, and detailed breakdowns per child
- Add scrollable lists for periods with many chores/extras

### Enhanced Payout Processing
- Update payout view to show detailed breakdown before confirming
- Grid layout displaying each chore/extra with completion timestamps
- Clear indication of exactly what will be paid out

### Navigation & Routes
- Add pay_periods routes for history access
- Add "View Full History" link from dashboard
- Maintain breadcrumb navigation throughout

Parents can now see exactly which chores/extras each child completed, when they were completed, and how much was earned for each item. Full historical records are preserved for all pay periods.

🤖 Generated with [Claude Code](https://claude.ai/code)